### PR TITLE
added more validation to the create-channel-dto

### DIFF
--- a/src/modules/admin/channel/dto/create-channel.dto.ts
+++ b/src/modules/admin/channel/dto/create-channel.dto.ts
@@ -5,6 +5,8 @@ export class CreateChannelDto {
   @IsString()
   name: string;
 
+  @IsNotEmpty()
+  @IsString()
   type: ChannelType;
 
   @IsNotEmpty()


### PR DESCRIPTION
- Even though type validation were added to the dto, it defaulted to the old behavior so I added the @IsNotEmpty and @IsString decorators
- I have also tested it this time so I won't bother you with the same issue again ( last time I did not and sorry for that).