### PR TITLE
Add DATABASE_URL environment variable to chat and database consumer s…

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -58,6 +58,7 @@ services:
     platform: linux/amd64
     environment:
       - RABBITMQ_URL=${RABBITMQ_URL}
+      - DATABASE_URL=${DATABASE_URL}
     command: ["node", "dist/src/apps/consumers/chat-consumer/main.js"]
 
   database-consumer:
@@ -66,6 +67,7 @@ services:
     platform: linux/amd64
     environment:
       - RABBITMQ_URL=${RABBITMQ_URL}
+      - DATABASE_URL=${DATABASE_URL}
     command: ["node", "dist/src/apps/consumers/database-consumer/main.js"]
 
 volumes:


### PR DESCRIPTION
This pull request includes updates to the `docker-compose.yml` file to ensure that the `DATABASE_URL` environment variable is correctly passed to the services.

Environment variable updates:

* [`docker-compose.yml`](diffhunk://#diff-e45e45baeda1c1e73482975a664062aa56f20c03dd9d64a827aba57775bed0d3R61): Added `DATABASE_URL` to the environment variables for the `chat-consumer` service.
* [`docker-compose.yml`](diffhunk://#diff-e45e45baeda1c1e73482975a664062aa56f20c03dd9d64a827aba57775bed0d3R70): Added `DATABASE_URL` to the environment variables for the `database-consumer` service.