### PR TITLE
Change the get all messages endpoint to be consistent with others

### DIFF
--- a/src/modules/admin/message/message.controller.ts
+++ b/src/modules/admin/message/message.controller.ts
@@ -4,7 +4,6 @@ import {
   Query,
   UseGuards,
   ValidationPipe,
-  Param,
 } from '@nestjs/common';
 import { MessageService } from './message.service';
 import { AuthGuard } from 'src/modules/auth/guard/auth/auth.guard';
@@ -14,9 +13,9 @@ import { AuthGuard } from 'src/modules/auth/guard/auth/auth.guard';
 export class MessageController {
   constructor(private readonly messageService: MessageService) {}
 
-  @Get(':accountId')
+  @Get()
   async getAllMessages(
-    @Param('accountId') accountId: string,
+    @Query('accountId') accountId: string,
     @Query(new ValidationPipe({ transform: true })) query: Record<string, any>,
   ) {
     return this.messageService.getAllMessages(accountId, query);

--- a/src/modules/admin/message/message.service.ts
+++ b/src/modules/admin/message/message.service.ts
@@ -19,6 +19,18 @@ export class MessageService {
     accountId: string,
     query: Record<string, any>,
   ): Promise<PaginationResult<Message>> {
+    if (!accountId) {
+      throw new Error('Account ID is required');
+    }
+
+    const accountExists = await this.prisma.account.findUnique({
+      where: { id: accountId },
+    });
+
+    if (!accountExists) {
+      throw new Error('Account does not exist');
+    }
+
     const paginationDto = new PaginationDto();
     paginationDto.page = query.page ? parseInt(query.page) : 1;
     paginationDto.limit = query.limit ? parseInt(query.limit) : 10;


### PR DESCRIPTION
This pull request involves changes to the `MessageController` and `MessageService` classes in the `src/modules/admin/message` directory. The changes focus on modifying the way account IDs are handled and adding validation checks.

Changes to account ID handling and validation:

* [`src/modules/admin/message/message.controller.ts`](diffhunk://#diff-31713d01e1a1b7c79e1e0401a846dd9ea89e50eda52380b054c601947b2cf3a3L17-R18): Updated the `getAllMessages` method to use a query parameter instead of a route parameter for the account ID.
* [`src/modules/admin/message/message.service.ts`](diffhunk://#diff-caccd9d97e09fcbe415b5acd7ece2776b7d5aef7d08e25e8754bbc0f3b90c7dcR22-R33): Added validation to check if the account ID is provided and if the account exists before proceeding with fetching messages.

Code cleanup:

* [`src/modules/admin/message/message.controller.ts`](diffhunk://#diff-31713d01e1a1b7c79e1e0401a846dd9ea89e50eda52380b054c601947b2cf3a3L7): Removed the unused `Param` import.