### PR TITLE
Bug/fixed role guard problem

### DIFF
--- a/src/modules/auth/guard/role/role.guard.ts
+++ b/src/modules/auth/guard/role/role.guard.ts
@@ -17,8 +17,9 @@ export class RoleGuard implements CanActivate {
 
     const user = context.switchToHttp().getRequest().user;
 
-    console.log('user data', user.accounts[0].role.name.toUpperCase());
-
-    return requiredRoles.some((role) => user.accounts?.[0]?.role?.name.toLowerCase() === role.toLowerCase());
+    return requiredRoles.some(
+      (role) =>
+        user.accounts?.[0]?.role?.name.toLowerCase() === role.toLowerCase(),
+    );
   }
 }

--- a/src/modules/auth/guard/role/role.guard.ts
+++ b/src/modules/auth/guard/role/role.guard.ts
@@ -2,7 +2,6 @@ import { CanActivate, ExecutionContext, Injectable } from '@nestjs/common';
 import { Reflector } from '@nestjs/core';
 import { Observable } from 'rxjs';
 import { ROLE_KEY } from '../../auth.decorator';
-import { User } from 'src/modules/admin/user/entities/user.entity';
 
 @Injectable()
 export class RoleGuard implements CanActivate {

--- a/src/modules/auth/guard/role/role.guard.ts
+++ b/src/modules/auth/guard/role/role.guard.ts
@@ -15,8 +15,10 @@ export class RoleGuard implements CanActivate {
       context.getClass(),
     ]);
 
-    const user: User = context.switchToHttp().getRequest().user;
+    const user = context.switchToHttp().getRequest().user;
 
-    return requiredRoles.some((role) => user.name === role);
+    console.log('user data', user.accounts[0].role.name.toUpperCase());
+
+    return requiredRoles.some((role) => user.accounts?.[0]?.role?.name.toLowerCase() === role.toLowerCase());
   }
 }

--- a/src/modules/auth/guard/role/role.guard.ts
+++ b/src/modules/auth/guard/role/role.guard.ts
@@ -16,9 +16,10 @@ export class RoleGuard implements CanActivate {
 
     const user = context.switchToHttp().getRequest().user;
 
-    return requiredRoles.some(
-      (role) =>
-        user.accounts?.[0]?.role?.name.toLowerCase() === role.toLowerCase(),
+    return user.accounts?.some((account) =>
+      requiredRoles.some(
+        (role) => account.role?.name.toLowerCase() === role.toLowerCase(),
+      ),
     );
   }
 }


### PR DESCRIPTION
There was an error in the role guard. The problem was the guard was trying to access the user.name property which does not exist. The correct property was user.accounts.role.name and even after finding that it doesn't match cuz our controller is passing the roles in upper case and our token is storing it in lowercase so...for that I changed the comparison logic to change both of them to lowercase and compare it...and now it is working